### PR TITLE
Deprecado registrySecret por su reemplazo registrySecrets

### DIFF
--- a/charts/argo-base-app/Chart.yaml
+++ b/charts/argo-base-app/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-base-app/README.md
+++ b/charts/argo-base-app/README.md
@@ -26,7 +26,9 @@ el cluster de Kubernetes. Básicamente se encarga de crear:
 |-----|------|---------|-------------|
 | `namespace` | string | `default-dev` | Namespace que utilizará el proyecto |
 | `namespaceLabels` | string | {} | Labels para el namespace creado |
-| `registrySecret.dockerconfigjson` | string | `null` | String encodeado que contiene los datos para conectarse a la registry, para instrucciones de cómo generarlo ver [Registry secret](##registry-secret) |
+| `registrySecret.name` | string | `container-registry` | **Deprecado**. Nombre del secreto usado por el [Registry secret](#registry-secret) |
+| `registrySecret.dockerconfigjson` | string | `null` | **Deprecado**. String encodeado que contiene los datos para conectarse a la registry, para instrucciones de cómo generarlo ver [Registry secret](#registry-secret) |
+| `registrySecrets` | list | `[]` | Lista de objetos con los campos `.name` y `.dockerconfigjson` para crear varios secretos que contienen los datos para conectarse a la registry, para instrucciones de cómo generarlo ver [Registry secret](#registry-secret). **Nueva funcionalidad que reemplaza `registrySecret`**. |
 | `quota.requests.enabled` | boolean | `true` | Definir el ResourceQuota. Por defecto sí |
 | `quota.requests.cpu` | string | `'1'` | La suma de los requerimientos de CPU de los pods del namespace, que estén no terminados, no puede superar este valor.  |
 | `quota.requests.memory` | string | `1Gi` | Idem ant. pero con los requerimientos de memoria  |
@@ -46,7 +48,7 @@ el cluster de Kubernetes. Básicamente se encarga de crear:
 
 ## Registry secret
 
-Ya que difieren las formas de conectarse a las distintas registrys, se deja a
+Ya que difieren las formas de conectarse a las distintas registries, se deja a
 criterio del usuario la forma de generar el `dockerconfigjson`.
 
 Una forma es utilizando `kubectl` con la opción `--dry-run` (para que no cree
@@ -69,7 +71,10 @@ eyJhdXRocyI6eyJyZWdpc3RyeS5pbnRhLmdvYi5hciI6eyJ1c2VybmFtZSI6IlVTVUFSSU8iLCJwYXNz
 ```
 
 Esto nos devuelve (y guarda en una variable de ambiente) el string que debemos
-utilizar en el valor `registrySecret.dockerconfigjson` del chart.
+utilizar en cada valor `registrySecrets[x].dockerconfigjson` del chart.
+
+> Antes el chart soportaba únicamente un único registrySecret. Ahora soporta una
+> lista de registrySecrets.
 
 Podemos ver que simplemente es un base 64 de un json de los datos provistos:
   

--- a/charts/argo-base-app/templates/NOTES.txt
+++ b/charts/argo-base-app/templates/NOTES.txt
@@ -1,0 +1,7 @@
+{{- if .Values.registrySecret.dockerconfigjson }}
+Deprecation warning!!
+
+Usage of .Values.registrySecret is deprecated. New versions will use
+.Values.registrySecrets, that is a list of objects with .name and
+.dockerconfigjson fields.
+{{- end }}

--- a/charts/argo-base-app/templates/registry-secret.yaml
+++ b/charts/argo-base-app/templates/registry-secret.yaml
@@ -9,3 +9,15 @@ metadata:
 data:
   .dockerconfigjson: {{ .Values.registrySecret.dockerconfigjson }}
 {{- end }}
+{{- range $o := .Values.registrySecrets }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  creationTimestamp: null
+  namespace: {{ $.Values.namespace }}
+  name: {{ $o.name }}
+data:
+  .dockerconfigjson: {{ $o.dockerconfigjson }}
+{{- end }}

--- a/charts/argo-base-app/values.yaml
+++ b/charts/argo-base-app/values.yaml
@@ -1,5 +1,10 @@
 namespace: default-dev
 namespaceLabels: {}
+registrySecrets: []
+# - name: container-registry
+#   dockerconfigjson: null
+
+# Deprecated. New versions will use registrySecrets instead of registrySecret
 registrySecret:
   name: container-registry
   dockerconfigjson: null


### PR DESCRIPTION
Ahora se admite una lista de secretos en vez de uno solo