### PR TITLE
Add extra-destinations to argo-project

### DIFF
--- a/charts/argo-project/Chart.yaml
+++ b/charts/argo-project/Chart.yaml
@@ -9,5 +9,5 @@ description: |
   allows bootstrapping an ArgoCD application to setup environment resources
   (as databases) and the project application itself.
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.16.0"

--- a/charts/argo-project/README.md
+++ b/charts/argo-project/README.md
@@ -28,6 +28,7 @@ Los valores más importantes a tener en cuenta:
 | `argo.readOnlyGroups` | string | `[]` | Lista de grupos de AD que tendrán acceso de solo lectura en el proyecto de ArgoCD. Solo pueden ver los objetos y leer logs |
 | `argo.adminGroups` | string | `[]` | Lista de grupos de AD que tendrán acceso de administradores. Son los encargados del despliegue, entre otras cosas puede sincronizar, eliminar aplicaciones y también ejecutar la consola de los contenedores |
 | `argo.repositories:` | {} | `[]` | Lista de repositorios scoped |
+| `argo.extraDestinations:` | [] | `[]` | Lista de namespaces de destino extra que se permitirán en el proyecto |
 | `argo.baseApplication.repoURL` | string | `null` | URL del repositorio donde está el chart de dicha aplicación |
 | `argo.baseApplication.path` | string | `null` | directorio donde se encuentra el chart en caso de ser un repo git |
 | `argo.baseApplication.chart` | string | `null` | nombre del chart en caso de usar una registry de charts

--- a/charts/argo-project/templates/argo-project.yaml
+++ b/charts/argo-project/templates/argo-project.yaml
@@ -1,3 +1,4 @@
+{{- $clusterName := include "argo-project.argoClusterName" . -}}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
@@ -13,7 +14,11 @@ spec:
   - '*'
   destinations:
   - namespace: {{ .Values.namespace }}
-    name: {{ include "argo-project.argoClusterName" . }}
+    name: {{ $clusterName }}
+  {{- range .Values.argo.extraDestinations }}
+  - namespace: {{ . }}
+    name: {{ $clusterName }}
+  {{- end }}
   namespaceResourceWhitelist:
   - group: "*"
     kind: "*"
@@ -26,7 +31,7 @@ spec:
     - p, proj:{{ include "argo-project.argoProjectName" . }}:admin, exec, create, {{ include "argo-project.argoProjectName" . }}/*, allow
     {{- with .Values.argo.adminGroups }}
     groups:
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
   - name: readonly
     description: "{{ include "argo-project.argoProjectName" . }} ReadOnly team's deployment role"
@@ -35,7 +40,7 @@ spec:
     - p, proj:{{ include "argo-project.argoProjectName" . }}:readonly, applications, logs, {{  include "argo-project.argoProjectName" . }}/*, allow
     {{- with .Values.argo.readOnlyGroups }}
     groups:
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
   orphanedResources:
     warn: false

--- a/charts/argo-project/values-example.yaml
+++ b/charts/argo-project/values-example.yaml
@@ -7,6 +7,9 @@ argo:
     - exampleADgroupRO
   adminGroups:
     - exampleADAdmin
+  extraDestinations:
+    - extra-namespace
+    - another-namespace
   repositories:
     - name: my-repo
       url: htts://a-url.repo.com/project/app


### PR DESCRIPTION
Traigo otro cambio de gitlab donde se agregan unos values para poder definir otros namespaces de destino en el proyecto de argo.